### PR TITLE
fix: typo in under construction page

### DIFF
--- a/prelaunch_static/index.html
+++ b/prelaunch_static/index.html
@@ -64,7 +64,7 @@
 	<h1>Rezofora</h1>
 	<article lang="fr">
 		<h2>En construction</h2>
-		<p>Vous êtes-bien sur le site de Rezofora, conseil et accompagnement en transition environnementale et numérique responsable.</p>
+		<p>Vous êtes bien sur le site de Rezofora, conseil et accompagnement en transition environnementale et numérique responsable.</p>
 		<p>À bientôt pour en savoir plus sur notre offre de conseil.</p>
 	</article>
 	<article lang="en">


### PR DESCRIPTION
Une petite erreur de ponctuation s'est malencontreusement glissée dans la page en construction. Cette PR propose une correction.